### PR TITLE
Updates to skinload

### DIFF
--- a/src/main/java/noppes/mpm/MorePlayerModels.java
+++ b/src/main/java/noppes/mpm/MorePlayerModels.java
@@ -211,7 +211,7 @@ public class MorePlayerModels {
     	 File dir = null;
          dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
 
-         if (!dir.exists()) return;
+         if (!dir.exists()) dir.mkdirs();
 
          NBTTagCompound compound = new NBTTagCompound();
          int i = 0;
@@ -235,6 +235,57 @@ public class MorePlayerModels {
 
             	 compound.setString(("skinName" + String.valueOf(i)), skinName);
             	 i++;
+             }
+         }
+
+         dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "unrestricted");
+
+         if (!dir.exists()) dir.mkdirs();
+
+         for (final File fileEntry : dir.listFiles()) {
+             if (fileEntry.isDirectory()) {
+                 continue;
+             } else {
+	             NBTTagCompound skinCompound = new NBTTagCompound();
+
+	             try {
+					skinCompound = CompressedStreamTools.readCompressed(new FileInputStream(fileEntry));
+				} catch (FileNotFoundException e) {
+				} catch (IOException e) {
+				}
+
+            	 String skinName = fileEntry.getName().substring(0, fileEntry.getName().length() - 4);
+
+            	 compound.setString(("skinName" + String.valueOf(i)), skinName);
+            	 i++;
+             }
+         }
+
+         if (!playersEntityDenied.contains(player.getUniqueID())) {
+        	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "restricted");
+
+             if (!dir.exists()) dir.mkdirs();
+
+             for (final File fileEntry : dir.listFiles()) {
+                 if (fileEntry.isDirectory()) {
+                     continue;
+                 } else {
+    	             NBTTagCompound skinCompound = new NBTTagCompound();
+
+    	             try {
+    					skinCompound = CompressedStreamTools.readCompressed(new FileInputStream(fileEntry));
+
+    					if (!skinCompound.getString("EntityClass").equals("") && playersEntityDenied.contains(player.getUniqueID()))
+    		            	 continue;
+    				} catch (FileNotFoundException e) {
+    				} catch (IOException e) {
+    				}
+
+                	 String skinName = fileEntry.getName().substring(0, fileEntry.getName().length() - 4);
+
+                	 compound.setString(("skinName" + String.valueOf(i)), skinName);
+                	 i++;
+                 }
              }
          }
 

--- a/src/main/java/noppes/mpm/MorePlayerModels.java
+++ b/src/main/java/noppes/mpm/MorePlayerModels.java
@@ -238,6 +238,7 @@ public class MorePlayerModels {
              }
          }
 
+         dir = null;
          dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "unrestricted");
 
          if (!dir.exists()) dir.mkdirs();
@@ -262,6 +263,7 @@ public class MorePlayerModels {
          }
 
          if (!playersEntityDenied.contains(player.getUniqueID())) {
+        	 dir = null;
         	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "restricted");
 
              if (!dir.exists()) dir.mkdirs();

--- a/src/main/java/noppes/mpm/PacketHandlerServer.java
+++ b/src/main/java/noppes/mpm/PacketHandlerServer.java
@@ -189,14 +189,37 @@ public class PacketHandlerServer {
 			File file;
 
 			File dir = null;
-			dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "propGroupsNamed");
-
-	        if (!dir.exists()) {
-	              return;
-	         }
 
 	        try {
+				dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "propGroupsNamed" + File.separator + "unrestricted");
+
+		        if (!dir.exists()) {
+		              dir.mkdirs();
+		         }
+
 	             file = new File(dir, filename);
+
+	             if (!file.exists()) {
+	            	 dir = null;
+	            	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "propGroupsNamed");
+
+	 		        if (!dir.exists()) {
+	 		              dir.mkdirs();
+	 		         }
+
+	 	             file = new File(dir, filename);
+	             }
+
+	             if (!file.exists()) {
+	            	 dir = null;
+	            	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "propGroupsNamed" + File.separator + "restricted");
+
+	 		        if (!dir.exists()) {
+	 		              dir.mkdirs();
+	 		         }
+
+	 	             file = new File(dir, filename);
+	             }
 
 	             if (!file.exists()) {
 	            	 return;

--- a/src/main/java/noppes/mpm/client/layer/LayerHead.java
+++ b/src/main/java/noppes/mpm/client/layer/LayerHead.java
@@ -231,6 +231,8 @@ public class LayerHead extends LayerInterface implements LayerPreRender  {
           this.player = player;
           this.playerdata = ModelData.get(player);
           ModelPartData data = this.playerdata.getOrCreatePart(EnumParts.HEAD);
-          this.model.bipedHead.isHidden = this.model.bipedHeadwear.isHidden = data == null || data.type != 0 || (this.playerdata.player == Minecraft.getMinecraft().thePlayer && Minecraft.getMinecraft().gameSettings.thirdPersonView == 0 && !(Minecraft.getMinecraft().currentScreen instanceof GuiNPCInterface));
+          this.model.bipedHead.isHidden = this.model.bipedHeadwear.isHidden = data == null || data.type != 0;
+          //The following code will fix compatibility with RealRender
+          //this.model.bipedHead.isHidden = this.model.bipedHeadwear.isHidden = data == null || data.type != 0 || (this.playerdata.player == Minecraft.getMinecraft().thePlayer && Minecraft.getMinecraft().gameSettings.thirdPersonView == 0 && !(Minecraft.getMinecraft().currentScreen instanceof GuiNPCInterface));
      }
 }

--- a/src/main/java/noppes/mpm/client/layer/LayerHead.java
+++ b/src/main/java/noppes/mpm/client/layer/LayerHead.java
@@ -1,11 +1,13 @@
 package noppes.mpm.client.layer;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.RenderPlayer;
 import noppes.mpm.ModelData;
 import noppes.mpm.ModelPartData;
+import noppes.mpm.client.gui.util.GuiNPCInterface;
 import noppes.mpm.client.model.Model2DRenderer;
 import noppes.mpm.client.model.part.head.ModelDuckBeak;
 import noppes.mpm.client.model.part.head.ModelHalo;
@@ -229,6 +231,6 @@ public class LayerHead extends LayerInterface implements LayerPreRender  {
           this.player = player;
           this.playerdata = ModelData.get(player);
           ModelPartData data = this.playerdata.getOrCreatePart(EnumParts.HEAD);
-          this.model.bipedHead.isHidden = this.model.bipedHeadwear.isHidden = data == null || data.type != 0;
+          this.model.bipedHead.isHidden = this.model.bipedHeadwear.isHidden = data == null || data.type != 0 || (this.playerdata.player == Minecraft.getMinecraft().thePlayer && Minecraft.getMinecraft().gameSettings.thirdPersonView == 0 && !(Minecraft.getMinecraft().currentScreen instanceof GuiNPCInterface));
      }
 }

--- a/src/main/java/noppes/mpm/commands/CommandPropRem.java
+++ b/src/main/java/noppes/mpm/commands/CommandPropRem.java
@@ -34,7 +34,17 @@ public class CommandPropRem extends CommandBase {
             	 return;
              }
 
-        	 file.delete();
+             File dirnew = null;
+             dirnew = new File(dirnew, ".." + File.separator + "moreplayermodels" + File.separator + "propGroupsNamed" + File.separator + "archive");
+
+             if (!dirnew.exists()) {
+            	 dirnew.mkdirs();
+            }
+
+             String filenamenew = args[0].toLowerCase() + "-" + System.currentTimeMillis() + ".dat";
+             File filenew = new File(dirnew, filenamenew);
+
+        	 file.renameTo(filenew);
         } catch (Exception var6) {
              LogWriter.except(var6);
              var6.printStackTrace();

--- a/src/main/java/noppes/mpm/commands/CommandSkinDel.java
+++ b/src/main/java/noppes/mpm/commands/CommandSkinDel.java
@@ -36,7 +36,17 @@ public class CommandSkinDel extends CommandBase {
             	 return;
              }
 
-        	 file.delete();
+             File dirnew = null;
+             dirnew = new File(dirnew, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "archive");
+
+             if (!dirnew.exists()) {
+            	 dirnew.mkdirs();
+            }
+
+             String filenamenew = args[0].toLowerCase() + "-" + System.currentTimeMillis() + ".dat";
+             File filenew = new File(dirnew, filenamenew);
+
+        	 file.renameTo(filenew);
         } catch (Exception var6) {
              LogWriter.except(var6);
              var6.printStackTrace();

--- a/src/main/java/noppes/mpm/commands/CommandSkinDel.java
+++ b/src/main/java/noppes/mpm/commands/CommandSkinDel.java
@@ -18,8 +18,6 @@ public class CommandSkinDel extends CommandBase {
 
 		if (args.length == 0) return;
 
-		NBTTagCompound compound = ModelData.get((EntityPlayer) icommandsender).writeToNBT();
-
         File dir = null;
         dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
         if (!dir.exists()) {

--- a/src/main/java/noppes/mpm/commands/CommandSkinLoad.java
+++ b/src/main/java/noppes/mpm/commands/CommandSkinLoad.java
@@ -35,25 +35,46 @@ public class CommandSkinLoad extends CommandBase {
 		String filename = args[0].toLowerCase() + ".dat";
 		File file;
 
-		File dir = null;
-		dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
-
-        if (!dir.exists()) {
-              return;
-         }
-
         try {
+    		 File dir = null;
+
+    		 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "unrestricted");
+
+             if (!dir.exists()) {
+                  dir.mkdirs();
+              }
+
              file = new File(dir, filename);
+
+             if (!file.exists()) {
+            	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
+
+                 if (!dir.exists()) {
+                      dir.mkdirs();
+                  }
+
+                 file = new File(dir, filename);
+
+                 NBTTagCompound compound = CompressedStreamTools.readCompressed(new FileInputStream(file));
+
+                 if (!compound.getString("EntityClass").equals("") && MorePlayerModels.playersEntityDenied.contains(((EntityPlayer) icommandsender).getUniqueID()))
+                	 return;
+             }
+
+             if (!file.exists() && MorePlayerModels.playersEntityDenied.contains(((EntityPlayer) icommandsender).getUniqueID())) {
+            	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "restricted");
+
+                 if (!dir.exists()) {
+                      dir.mkdirs();
+                  }
+
+                 file = new File(dir, filename);
+             }
 
              if (!file.exists()) {
             	 icommandsender.addChatMessage(new TextComponentTranslation("The skin " + args[0] + " was not found on the server."));
             	 return;
              }
-
-             NBTTagCompound compound = CompressedStreamTools.readCompressed(new FileInputStream(file));
-
-             if (!compound.getString("EntityClass").equals("") && MorePlayerModels.playersEntityDenied.contains(((EntityPlayer) icommandsender).getUniqueID()))
-            	 return;
 
              Server.sendAssociatedData((Entity) icommandsender, EnumPackets.SEND_PLAYER_DATA, ((Entity) icommandsender).getUniqueID(), compound);
         } catch (Exception var4) {

--- a/src/main/java/noppes/mpm/commands/CommandSkinLoad.java
+++ b/src/main/java/noppes/mpm/commands/CommandSkinLoad.java
@@ -49,6 +49,7 @@ public class CommandSkinLoad extends CommandBase {
              NBTTagCompound compound = new NBTTagCompound();
 
              if (!file.exists()) {
+            	 dir = null;
             	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
 
                  if (!dir.exists()) {
@@ -66,6 +67,7 @@ public class CommandSkinLoad extends CommandBase {
              }
 
              if (!file.exists() && MorePlayerModels.playersEntityDenied.contains(((EntityPlayer) icommandsender).getUniqueID())) {
+            	 dir = null;
             	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "restricted");
 
                  if (!dir.exists()) {

--- a/src/main/java/noppes/mpm/commands/CommandSkinLoad.java
+++ b/src/main/java/noppes/mpm/commands/CommandSkinLoad.java
@@ -46,6 +46,8 @@ public class CommandSkinLoad extends CommandBase {
 
              file = new File(dir, filename);
 
+             NBTTagCompound compound = new NBTTagCompound();
+
              if (!file.exists()) {
             	 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
 
@@ -55,10 +57,12 @@ public class CommandSkinLoad extends CommandBase {
 
                  file = new File(dir, filename);
 
-                 NBTTagCompound compound = CompressedStreamTools.readCompressed(new FileInputStream(file));
+                 if (file.exists()) {
+                	 NBTTagCompound temp = CompressedStreamTools.readCompressed(new FileInputStream(file));
 
-                 if (!compound.getString("EntityClass").equals("") && MorePlayerModels.playersEntityDenied.contains(((EntityPlayer) icommandsender).getUniqueID()))
-                	 return;
+                     if (!temp.getString("EntityClass").equals("") && MorePlayerModels.playersEntityDenied.contains(((EntityPlayer) icommandsender).getUniqueID()))
+                    	 return;
+                 }
              }
 
              if (!file.exists() && MorePlayerModels.playersEntityDenied.contains(((EntityPlayer) icommandsender).getUniqueID())) {
@@ -74,6 +78,8 @@ public class CommandSkinLoad extends CommandBase {
              if (!file.exists()) {
             	 icommandsender.addChatMessage(new TextComponentTranslation("The skin " + args[0] + " was not found on the server."));
             	 return;
+             } else {
+            	 compound = CompressedStreamTools.readCompressed(new FileInputStream(file));
              }
 
              Server.sendAssociatedData((Entity) icommandsender, EnumPackets.SEND_PLAYER_DATA, ((Entity) icommandsender).getUniqueID(), compound);

--- a/src/main/java/noppes/mpm/commands/CommandSkinSave.java
+++ b/src/main/java/noppes/mpm/commands/CommandSkinSave.java
@@ -23,22 +23,41 @@ public class CommandSkinSave extends CommandBase {
 		NBTTagCompound compound = ModelData.get((EntityPlayer) icommandsender).writeToNBT();
 
         File dir = null;
-        dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
-        if (!dir.exists()) {
-             dir.mkdirs();
-        }
 
         String filename = args[0].toLowerCase() + ".dat";
 
         try {
+            dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "unrestricted");
+            if (!dir.exists()) {
+                 dir.mkdirs();
+            }
+
              File file = new File(dir, filename);
 
-             if (file.exists()) {
-            	 icommandsender.addChatMessage(new TextComponentTranslation("The skin " + args[0] + " already exists. Either /skindel the old version first, or give this one a new name"));
-            	 return;
+             if (!file.exists()) {
+                 dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "restricted");
+                 if (!dir.exists()) {
+                      dir.mkdirs();
+                 }
+
+                  file = new File(dir, filename);
              }
 
-             CompressedStreamTools.writeCompressed(compound, new FileOutputStream(file));
+              if (!file.exists()) {
+            	  dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
+                  if (!dir.exists()) {
+                       dir.mkdirs();
+                  }
+
+                   file = new File(dir, filename);
+              }
+
+               if (file.exists()) {
+              	 icommandsender.addChatMessage(new TextComponentTranslation("The skin " + args[0] + " already exists. Either /skindel the old version first, or give this one a new name"));
+              	 return;
+               }
+
+               CompressedStreamTools.writeCompressed(compound, new FileOutputStream(file));
         } catch (Exception var6) {
              LogWriter.except(var6);
              var6.printStackTrace();

--- a/src/main/java/noppes/mpm/commands/CommandSkinSave.java
+++ b/src/main/java/noppes/mpm/commands/CommandSkinSave.java
@@ -35,6 +35,7 @@ public class CommandSkinSave extends CommandBase {
              File file = new File(dir, filename);
 
              if (!file.exists()) {
+            	 dir = null;
                  dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins" + File.separator + "restricted");
                  if (!dir.exists()) {
                       dir.mkdirs();
@@ -44,6 +45,7 @@ public class CommandSkinSave extends CommandBase {
              }
 
               if (!file.exists()) {
+            	  dir = null;
             	  dir = new File(dir, ".." + File.separator + "moreplayermodels" + File.separator + "skins");
                   if (!dir.exists()) {
                        dir.mkdirs();


### PR DESCRIPTION
Bugfix: Added a commented fix to the FirstPersonRender bug that makes you render your head while in first person.
This is left as a comment since it was decided to remove the mod from the pack anyway

/skindel and /proprem will now archive the .dat files rather than delete them

Added two subfolders for saved skins:
"unrestricted" will not check for hasEntityPermission. This allows us to curate some easy difficulty entity models
"restricted" can only be loaded with hasEntityPermission, whether they contain an entity or not.