### PR TITLE
Added two new configs

### DIFF
--- a/src/main/java/noppes/mpm/MorePlayerModels.java
+++ b/src/main/java/noppes/mpm/MorePlayerModels.java
@@ -128,11 +128,13 @@ public class MorePlayerModels {
      @ConfigProp(
           info = "Used to register buttons to animations"
      )
+     public static int button5;
      public static boolean hasEntityPermission;
      public static List<UUID> playersEntityDenied;
      public static List<String> fileNamesSkins;
      public static List<String> fileNamesPropGroups;
-     public static int button5;
+     public static List<String> entityNamesRemovedFromGui;
+     public static List<String> blacklistedPropStrings;
      public ConfigLoader configLoader;
 
      public MorePlayerModels() {
@@ -148,6 +150,9 @@ public class MorePlayerModels {
           if (!MorePlayerModels.dir.exists()) {
                MorePlayerModels.dir.mkdir();
           }
+
+          entityNamesRemovedFromGui = new ArrayList<String>();
+          blacklistedPropStrings = new ArrayList<String>();
 
           this.configLoader = new ConfigLoader(this.getClass(), new File(dir, "config"), "MorePlayerModels");
           this.configLoader.loadConfig();

--- a/src/main/java/noppes/mpm/Prop.java
+++ b/src/main/java/noppes/mpm/Prop.java
@@ -118,6 +118,10 @@ public class Prop {
      }
 
      public boolean parsePropString(String propString) {
+    	 for (String string : MorePlayerModels.blacklistedPropStrings) {
+    		 if (propString.contains(string)) return false;
+    	 }
+
     	 String nameSpacedId = "";
     	 short dataValue = 0;
 

--- a/src/main/java/noppes/mpm/Prop.java
+++ b/src/main/java/noppes/mpm/Prop.java
@@ -119,7 +119,7 @@ public class Prop {
 
      public boolean parsePropString(String propString) {
     	 for (String string : MorePlayerModels.blacklistedPropStrings) {
-    		 if (propString.contains(string)) return false;
+    		 if (propString.toLowerCase().contains(string.toLowerCase())) return false;
     	 }
 
     	 String nameSpacedId = "";

--- a/src/main/java/noppes/mpm/client/gui/GuiCreationEntities.java
+++ b/src/main/java/noppes/mpm/client/gui/GuiCreationEntities.java
@@ -37,7 +37,8 @@ public class GuiCreationEntities extends GuiCreationScreenInterface implements I
                try {
                     Class c = ent.getEntityClass();
                     if (EntityLiving.class.isAssignableFrom(c) && c.getConstructor(World.class) != null && !Modifier.isAbstract(c.getModifiers()) && Minecraft.getMinecraft().getRenderManager().getEntityClassRenderObject(c) instanceof RenderLivingBase) {
-                         this.data.put(name, c.asSubclass(EntityLivingBase.class));
+                    	if (!MorePlayerModels.entityNamesRemovedFromGui.contains(name.toLowerCase()))
+                    		this.data.put(name, c.asSubclass(EntityLivingBase.class));
                     }
                } catch (SecurityException var5) {
                     var5.printStackTrace();

--- a/src/main/java/noppes/mpm/config/ConfigLoader.java
+++ b/src/main/java/noppes/mpm/config/ConfigLoader.java
@@ -11,6 +11,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 
+import noppes.mpm.MorePlayerModels;
+import noppes.mpm.PropGroup;
+
 public class ConfigLoader {
      private boolean updateFile = false;
      private File dir;
@@ -105,6 +108,28 @@ public class ConfigLoader {
                          } while(strLine.startsWith("#"));
                     } while(strLine.length() == 0);
 
+ 	               if (strLine.contains("entityNamesRemovedFromGui")) {
+	                  	MorePlayerModels.entityNamesRemovedFromGui.clear();
+	                  	for (int i = 0; i < Integer.MAX_VALUE; i++) {
+	                  		String string = reader.readLine();
+	                  		if (string.length() > 0) {
+	                  			MorePlayerModels.entityNamesRemovedFromGui.add(string);
+	              		    } else {
+	              		    	break;
+	              		    }
+	                      }
+	              } else if (strLine.contains("blacklistedPropStrings")) {
+	                  	MorePlayerModels.blacklistedPropStrings.clear();
+	                  	for (int i = 0; i < Integer.MAX_VALUE; i++) {
+	                  		String string = reader.readLine();
+	                  		if (string.length() > 0) {
+	                  			MorePlayerModels.blacklistedPropStrings.add(string);
+	              		    } else {
+	              		    	break;
+	              		    }
+	                  	}
+	               }
+
                     int index = strLine.indexOf("=");
                     if (index > 0 && index != strLine.length()) {
                          String name = strLine.substring(0, index);
@@ -170,6 +195,20 @@ public class ConfigLoader {
                          var9.printStackTrace();
                     }
                }
+
+               out.write("#Entity names that you want removed from the entity GUI" + System.getProperty("line.separator"));
+               out.write("entityNamesRemovedFromGui:" + System.getProperty("line.separator"));
+               for (String string : MorePlayerModels.entityNamesRemovedFromGui) {
+            	   out.write(string + System.getProperty("line.separator"));
+               }
+               out.write(System.getProperty("line.separator"));
+
+               out.write("#Banned terms in propstrings. This will block any prop that contains the listed strings" + System.getProperty("line.separator"));
+               out.write("blacklistedPropStrings:" + System.getProperty("line.separator"));
+               for (String string : MorePlayerModels.blacklistedPropStrings) {
+            	   out.write(string + System.getProperty("line.separator"));
+               }
+               out.write(System.getProperty("line.separator"));
 
                out.close();
           } catch (IOException var10) {

--- a/src/main/java/noppes/mpm/config/ConfigLoader.java
+++ b/src/main/java/noppes/mpm/config/ConfigLoader.java
@@ -111,7 +111,7 @@ public class ConfigLoader {
  	               if (strLine.contains("entityNamesRemovedFromGui")) {
 	                  	MorePlayerModels.entityNamesRemovedFromGui.clear();
 	                  	for (int i = 0; i < Integer.MAX_VALUE; i++) {
-	                  		String string = reader.readLine();
+	                  		String string = reader.readLine().toLowerCase();
 	                  		if (string.length() > 0) {
 	                  			MorePlayerModels.entityNamesRemovedFromGui.add(string);
 	              		    } else {


### PR DESCRIPTION
blackListedPropStrings:
A config that will blacklist any prop for which the string contains any object on this list

entityNamesRemovedFromGui:
Entities that won't be shown in the entity gui. It will only work on the GUI because this is mostly for entities that cause client crashes.