### PR TITLE
Sneaky rp dev momo

### DIFF
--- a/src/main/java/noppes/mpm/Prop.java
+++ b/src/main/java/noppes/mpm/Prop.java
@@ -35,6 +35,7 @@ public class Prop {
 	public Float ppOffsetX = 0.0F;
 	public Float ppOffsetY = 0.0F;
 	public Float ppOffsetZ = 0.0F;
+	public Boolean lockrotation = false;
 
 	public enum EnumType {
 		ITEM,
@@ -74,7 +75,7 @@ public class Prop {
 	Float motionScatter, Float frequency, int amount,
 	Float offsetX, Float offsetY, Float offsetZ,
 	Float pitch, Float yaw, Double speed,
-	Boolean hide, String name)
+	Boolean hide, String name, Boolean lockrotation)
 	{
 		this.propString = propString;
 		this.parsePropString(this.propString);
@@ -90,6 +91,7 @@ public class Prop {
 		this.speed = speed;
 		this.hide = hide;
 		this.name = name;
+		this.lockrotation = lockrotation;
 	}
 
 	public NBTTagCompound writeToNBT() {
@@ -117,6 +119,7 @@ public class Prop {
 		compound.setFloat("ppOffsetX", this.ppOffsetX);
 		compound.setFloat("ppOffsetY", this.ppOffsetY);
 		compound.setFloat("ppOffsetZ", this.ppOffsetZ);
+		compound.setBoolean("lockrotation", this.lockrotation);
 		return compound;
 	}
 
@@ -145,6 +148,7 @@ public class Prop {
 		this.ppOffsetX = compound.getFloat("ppOffsetX");
 		this.ppOffsetY = compound.getFloat("ppOffsetY");
 		this.ppOffsetZ = compound.getFloat("ppOffsetZ");
+		this.lockrotation = compound.getBoolean("lockrotation");
 	}
 
 	public String getCommand() {
@@ -163,7 +167,7 @@ public class Prop {
 			this.scatter + " " + this.frequency + " " + this.amount + " " +
 			this.offsetX + " " + this.offsetY + " " + this.offsetZ + " " +
 			this.pitch + " " + this.yaw + " " + this.speed + " " +
-			this.hide + " " + this.name;
+			this.hide + " " + this.name + " " + this.lockrotation;
 		}
 
 		return command;

--- a/src/main/java/noppes/mpm/client/gui/GuiCreationProps.java
+++ b/src/main/java/noppes/mpm/client/gui/GuiCreationProps.java
@@ -280,6 +280,9 @@ public class GuiCreationProps extends GuiCreationScreenInterface implements ISli
 						this.getSlider(514).displayString = "Speed";
 					}
 					y += 22;
+					this.addLabel(new GuiNpcLabel(129, "gui.lockrotation", guiOffsetX, y + 5, 16777215));
+					this.addButton(new GuiNpcButton(129, guiOffsetX + 98, y, 55, 20, new String[]{"gui.false", "gui.true"}, prop.lockrotation ? 1 : 0));
+					y += 22;
 					this.addButton(new GuiNpcButton(122, guiOffsetX, y, 152, 20, "gui.propgroup"));
 				}
 				this.getButton(sliders).enabled = false;
@@ -446,6 +449,8 @@ public class GuiCreationProps extends GuiCreationScreenInterface implements ISli
 		} else if (btn.id == 124) {
 			advanced = ((GuiNpcButton)btn).getValue() == 1 ? true : false;
 			this.initGui();
+		} else if (btn.id == 129) {
+			prop.lockrotation = ((GuiNpcButton)btn).getValue() == 1 ? true : false;
 		}
 	}
 

--- a/src/main/java/noppes/mpm/client/layer/LayerProp.java
+++ b/src/main/java/noppes/mpm/client/layer/LayerProp.java
@@ -627,7 +627,7 @@ public class LayerProp extends LayerInterface {
 					Double propMotionXCorrected = null;
 					Double propMotionYCorrected = null;
 					Double propMotionZCorrected = null;
-					if (prop.bodyPartName.equals("model")) {
+					if (prop.bodyPartName.equals("model") || prop.lockrotation) {
 						//Calculate particle motion
 						//Apply pitch
 						propMotionYCorrected = propMotionSpeed * Math.cos(propMotionPitch);

--- a/src/main/java/noppes/mpm/client/layer/LayerProp.java
+++ b/src/main/java/noppes/mpm/client/layer/LayerProp.java
@@ -53,9 +53,7 @@ public class LayerProp extends LayerInterface {
 			Minecraft minecraft = Minecraft.getMinecraft();
 
 			ModelRenderer propBodyPart = null;
-			ModelRenderer motherRenderer = new ModelRenderer(this.model);
 			ModelRenderer propRenderer = new ModelRenderer(this.model);
-			motherRenderer.addChild(propRenderer);
 
 			ItemStack propItemStack = prop.itemStack;
 			Float propScaleX = prop.scaleX;
@@ -72,16 +70,12 @@ public class LayerProp extends LayerInterface {
 			Float propPpOffsetY = prop.ppOffsetY;
 			Float propPpOffsetZ = prop.ppOffsetZ;
 
-			Float partModifierX = 0.0F;
-			Float partModifierY = 0.0F;
-			Float partModifierZ = 0.0F;
 			EnumParts enumPart = null;
 
 			switch(prop.bodyPartName) {
 				case "hat":
 				case "head":
 				propBodyPart = this.model.bipedHead;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY);
 
 				enumPart = EnumParts.HEAD;
 
@@ -95,7 +89,6 @@ public class LayerProp extends LayerInterface {
 				break;
 				case "model":
 				propBodyPart = this.model.bipedBody;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY);
 
 				enumPart = EnumParts.BODY;
 
@@ -110,7 +103,6 @@ public class LayerProp extends LayerInterface {
 				case "body":
 				case "torso":
 				propBodyPart = this.model.bipedBody;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY);
 
 				enumPart = EnumParts.BODY;
 
@@ -124,7 +116,6 @@ public class LayerProp extends LayerInterface {
 				break;
 				case "back":
 				propBodyPart = this.model.bipedBody;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY);
 
 				enumPart = EnumParts.BODY;
 
@@ -140,8 +131,6 @@ public class LayerProp extends LayerInterface {
 				case "armleft":
 				case "leftarm":
 				propBodyPart = this.model.bipedLeftArm;
-				partModifierX = (-0.25F * this.playerdata.getPartConfig(EnumParts.BODY).scaleX) + (-0.0625F * this.playerdata.getPartConfig(EnumParts.ARM_LEFT).scaleX);
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY - 0.125  * this.playerdata.getPartConfig(EnumParts.ARM_LEFT).scaleY);
 
 				enumPart = EnumParts.ARM_LEFT;
 
@@ -157,8 +146,6 @@ public class LayerProp extends LayerInterface {
 				case "handleft":
 				case "lefthand":
 				propBodyPart = this.model.bipedLeftArm;
-				partModifierX = (-0.25F * this.playerdata.getPartConfig(EnumParts.BODY).scaleX) + (-0.0625F * this.playerdata.getPartConfig(EnumParts.ARM_LEFT).scaleX);
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY - 0.125  * this.playerdata.getPartConfig(EnumParts.ARM_LEFT).scaleY);
 
 				enumPart = EnumParts.ARM_LEFT;
 
@@ -173,8 +160,6 @@ public class LayerProp extends LayerInterface {
 				case "armright":
 				case "rightarm":
 				propBodyPart = this.model.bipedRightArm;
-				partModifierX = (0.25F * this.playerdata.getPartConfig(EnumParts.BODY).scaleX) + (0.0625F * this.playerdata.getPartConfig(EnumParts.ARM_RIGHT).scaleX);
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY - 0.125  * this.playerdata.getPartConfig(EnumParts.ARM_RIGHT).scaleY);
 
 				enumPart = EnumParts.ARM_RIGHT;
 
@@ -189,8 +174,6 @@ public class LayerProp extends LayerInterface {
 				case "handright":
 				case "righthand":
 				propBodyPart = this.model.bipedRightArm;
-				partModifierX = (0.25F * this.playerdata.getPartConfig(EnumParts.BODY).scaleX) + (0.0625F * this.playerdata.getPartConfig(EnumParts.ARM_RIGHT).scaleX);
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY + 0.75 * this.playerdata.getPartConfig(EnumParts.BODY).scaleY - 0.125  * this.playerdata.getPartConfig(EnumParts.ARM_RIGHT).scaleY);
 
 				enumPart = EnumParts.ARM_RIGHT;
 
@@ -206,8 +189,6 @@ public class LayerProp extends LayerInterface {
 				case "legleft":
 				case "leftleg":
 				propBodyPart = this.model.bipedLeftLeg;
-				partModifierX = -0.125F * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleX;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY);
 
 				enumPart = EnumParts.LEG_LEFT;
 
@@ -223,8 +204,6 @@ public class LayerProp extends LayerInterface {
 				case "footleft":
 				case "leftfoot":
 				propBodyPart = this.model.bipedLeftLeg;
-				partModifierX = -0.125F * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleX;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_LEFT).scaleY);
 
 				enumPart = EnumParts.LEG_LEFT;
 
@@ -239,8 +218,6 @@ public class LayerProp extends LayerInterface {
 				case "legright":
 				case "rightleg":
 				propBodyPart = this.model.bipedRightLeg;
-				partModifierX = 0.125F * this.playerdata.getPartConfig(EnumParts.LEG_RIGHT).scaleX;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_RIGHT).scaleY);
 
 				enumPart = EnumParts.LEG_RIGHT;
 
@@ -255,8 +232,6 @@ public class LayerProp extends LayerInterface {
 				case "footright":
 				case "rightfoot":
 				propBodyPart = this.model.bipedRightLeg;
-				partModifierX = 0.125F * this.playerdata.getPartConfig(EnumParts.LEG_RIGHT).scaleX;
-				partModifierY = (float) (-1.5F + 0.75 * this.playerdata.getPartConfig(EnumParts.LEG_RIGHT).scaleY);
 
 				enumPart = EnumParts.LEG_RIGHT;
 
@@ -270,17 +245,10 @@ public class LayerProp extends LayerInterface {
 				break;
 			}
 
+			propBodyPart.addChild(propRenderer);
+
 			if (propBodyPart == this.model.bipedHead && this.playerdata.player == minecraft.thePlayer && minecraft.gameSettings.thirdPersonView == 0 && !(minecraft.currentScreen instanceof GuiNPCInterface))
 			return;
-
-			if (this.player.isSneaking()) {
-				if (propBodyPart == this.model.bipedLeftLeg || propBodyPart == this.model.bipedRightLeg) {
-					partModifierY += 0.1875F;
-					partModifierZ -= 0.25F;
-				} else if (propBodyPart == this.model.bipedHead) {
-					partModifierY -= 0.0625F;
-				}
-			}
 
 			Float propOffsetXCorrected;
 			Float propOffsetYCorrected;
@@ -344,10 +312,6 @@ public class LayerProp extends LayerInterface {
 
 				propOffsetXCorrected = (float) (Math.sin(anglePrev - propBodyPart.rotateAngleZ) * hyp);
 				propOffsetYCorrected = (float) (Math.cos(anglePrev - propBodyPart.rotateAngleZ) * hyp);
-
-				motherRenderer.rotateAngleX = propBodyPart.rotateAngleX;
-				motherRenderer.rotateAngleY = propBodyPart.rotateAngleY;
-				motherRenderer.rotateAngleZ = propBodyPart.rotateAngleZ;
 			}
 
 			if (propMatchScaling == true) {
@@ -358,8 +322,8 @@ public class LayerProp extends LayerInterface {
 
 			GlStateManager.pushMatrix();
 
-			GlStateManager.translate((propBodyPart.offsetX - propOffsetXCorrected - partModifierX - propPpOffsetX), (propBodyPart.offsetY - propOffsetYCorrected - partModifierY - propPpOffsetY), (propBodyPart.offsetZ - propOffsetZCorrected - partModifierZ - propPpOffsetZ));
-			motherRenderer.postRender(par7);
+			GlStateManager.translate((propBodyPart.offsetX - propOffsetXCorrected - propPpOffsetX), (propBodyPart.offsetY - propOffsetYCorrected - propPpOffsetY), (propBodyPart.offsetZ - propOffsetZCorrected - propPpOffsetZ));
+			propBodyPart.postRender(par7);
 
 			GlStateManager.rotate(propRotateX, 1.0F, 0.0F, 0.0F);
 			GlStateManager.rotate(propRotateY, 0.0F, 1.0F, 0.0F);

--- a/src/main/java/noppes/mpm/client/layer/LayerProp.java
+++ b/src/main/java/noppes/mpm/client/layer/LayerProp.java
@@ -565,9 +565,9 @@ public class LayerProp extends LayerInterface {
 					Float propOffsetZCorrected;
 
 					if (prop.bodyPartName.equals("model")) {
-						propOffsetXCorrected = propOffsetX - propBodyPart.offsetX - this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_X];
+						propOffsetXCorrected = propOffsetX - propBodyPart.offsetX - (this.playerdata.animStates == null ? 0.0F : this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_X]);
 						propOffsetYCorrected = propOffsetY;
-						propOffsetZCorrected = propOffsetZ - propBodyPart.offsetZ - this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL +  Emote.OFF_Z];
+						propOffsetZCorrected = propOffsetZ - propBodyPart.offsetZ - (this.playerdata.animStates == null ? 0.0F : this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_Z]);
 					} else {
 						//Calculate prop offset
 						Float anglePrev;
@@ -604,7 +604,7 @@ public class LayerProp extends LayerInterface {
 						}
 
 						Float Xyaw = (float) (Math.sin(anglePrev + propBodyPart.rotateAngleY) * hyp);
-						propOffsetZCorrected = (float) (Math.cos(anglePrev + propBodyPart.rotateAngleY) * hyp) - propBodyPart.offsetZ - this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL +  Emote.OFF_Z];
+						propOffsetZCorrected = (float) (Math.cos(anglePrev + propBodyPart.rotateAngleY) * hyp) - propBodyPart.offsetZ - (this.playerdata.animStates == null ? 0.0F : this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_Z]);
 
 						//Apply roll
 						if (Xyaw > -0.0001 && Xyaw < 0.0001) {
@@ -620,7 +620,7 @@ public class LayerProp extends LayerInterface {
 							hyp = (float) (Xyaw / Math.sin(anglePrev));
 						}
 
-						propOffsetXCorrected = (float) (Math.sin(anglePrev - propBodyPart.rotateAngleZ) * hyp) - propBodyPart.offsetX - this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_X];
+						propOffsetXCorrected = (float) (Math.sin(anglePrev - propBodyPart.rotateAngleZ) * hyp) - propBodyPart.offsetX - (this.playerdata.animStates == null ? 0.0F : this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_X]);
 						propOffsetYCorrected = (float) (Math.cos(anglePrev - propBodyPart.rotateAngleZ) * hyp);
 					}
 
@@ -673,7 +673,7 @@ public class LayerProp extends LayerInterface {
 
 					this.player.worldObj.spawnParticle(propParticleType,
 						this.player.posX - propOffsetXCorrected2 - partModifierXCorrected,
-						this.player.posY + propOffsetYCorrected + partModifierY - propBodyPart.offsetY - this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_Y],
+						this.player.posY + propOffsetYCorrected + partModifierY - propBodyPart.offsetY - (this.playerdata.animStates == null ? 0.0F : this.playerdata.animStates[Emote.AXIS_COUNT*Emote.MODEL + Emote.OFF_Y]),
 						this.player.posZ + propOffsetZCorrected2 + partModifierZCorrected,
 						propMotionXCorrected, propMotionYCorrected, propMotionZCorrected);
 				}

--- a/src/main/java/noppes/mpm/commands/CommandProp.java
+++ b/src/main/java/noppes/mpm/commands/CommandProp.java
@@ -257,12 +257,13 @@ public class CommandProp extends MpmCommandInterface {
 			Double propSpeed = (args.length > 10) ? Double.valueOf(args[10]) : 0.0F;
 			Boolean propHide = (args.length > 11) ? parseBoolean(args[11]) : false;
 			String propName = (args.length > 12) ? args[12] : "NONAME";
+			Boolean lockrotation = (args.length > 13) ? parseBoolean(args[13]) : false;
 
 			prop = new Prop(propString, bodyPartName,
 			propMotionScatter, propFrequency, propAmount,
 			propOffsetX, propOffsetY, propOffsetZ,
 			propPitch, propYaw, propSpeed,
-			propHide, propName);
+			propHide, propName, lockrotation);
 		}
 
 

--- a/src/main/resources/assets/moreplayermodels/lang/en_US.lang
+++ b/src/main/resources/assets/moreplayermodels/lang/en_US.lang
@@ -79,6 +79,7 @@ gui.paste=Paste
 gui.type.keyframe=Keyframe
 gui.type.command=Command
 gui.command=Command
+gui.lockrotation=Lock Rotation
 
 gui.usageflag.loop_only_stops_at_boundary=Loop only stops at boundary
 gui.usageflag.loop_pauses_when_still=Loop pauses when not moving


### PR DESCRIPTION
Fixed a bug that caused a nullpointer while rendering particle props
Added a toggle to lock the rotation of particle props (such as a smoke particle that should always go up no matter how you hold the prop)
Made the prop renderer more efficient by using the limbs own ModelRenderer rather than creating a mother renderer